### PR TITLE
Add database constraints for item name length

### DIFF
--- a/db/migrate/20251029014735_limit_item_name_length.rb
+++ b/db/migrate/20251029014735_limit_item_name_length.rb
@@ -1,0 +1,5 @@
+class LimitItemNameLength < ActiveRecord::Migration[8.1]
+  def change
+    change_column :items, :name, :string, limit: 50
+  end
+end

--- a/db/migrate/20251029015447_enforce_not_null_on_item_name.rb
+++ b/db/migrate/20251029015447_enforce_not_null_on_item_name.rb
@@ -1,0 +1,5 @@
+class EnforceNotNullOnItemName < ActiveRecord::Migration[8.1]
+  def change
+    change_column :items, :name, :string, limit: 50, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_10_27_200807) do
+ActiveRecord::Schema[8.1].define(version: 2025_10_29_015447) do
   create_table "items", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "name", null: false
+    t.string "name", limit: 50, null: false
     t.integer "status", default: 0
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_items_on_name", unique: true


### PR DESCRIPTION
Accidentally removed null: false on the first migration, so second migration corrects that.